### PR TITLE
Feat: Move global args to the plan args to increase configurability

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,54 @@ Simply run
 kurtosis run github.com/kurtosis-tech/rabbitmq-package
 ```
 
-If you want to override the number of nodes:
+Both the management (default: 15672) and AMQP (default: 5672) ports are exposed.  An administrator user "admin" is created with a default password set to "admin".
 
-```
-kurtosis run github.com/kurtosis-tech/rabbitmq-package '{"num_nodes": <required_number_of_nodes>}'
+### Configuration
+
+<details>
+    <summary>Click to see configuration</summary>
+
+You can configure this package using a JSON structure as an argument to the `kurtosis run` function. The full structure that this package accepts is as follows, with default values shown (note that the `//` lines are not valid JSON and should be removed!):
+
+```javascript
+{
+    // The number of nodes
+    "rabbitmq_num_nodes": 3,
+
+    // The image to run
+    "rabbitmq_image": "rabbitmq:3-management",
+
+    // The management interface port number
+    "rabbitmq_management_port": 15672,
+
+    // The AMQP interface port number
+    "rabbitmq_amqp_port": 5672,
+
+    // The administrator user name and password
+    "rabbitmq_admin_user": "admin",
+    "rabbitmq_admin_password": "admin",
+
+    // The virtual host to create
+    "rabbitmq_vhost": "test",
+
+    // Additional environment variables that will be set on the container
+    "rabbitmq_env_vars": {}
+}
 ```
 
-Both the management (15672) and AMQP (5672) ports are exposed.  An administrator user "admin" is created with a default password set to "admin".
+These arguments can either be provided manually:
+
+```bash
+kurtosis run github.com/kurtosis-tech/rabbitmq-package '{"image":"rabbitmq:3-management"}'
+```
+
+or by loading via a file, for instance using the [args.json](args.json) file in this repo:
+
+```bash
+kurtosis run github.com/kurtosis-tech/rabbitmq-package --enclave rabbitmq "$(cat args.json)"
+```
+
+</details>
 
 ### etcd
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ kurtosis run github.com/kurtosis-tech/rabbitmq-package
 
 Both the management (default: 15672) and AMQP (default: 5672) ports are exposed.  An administrator user "admin" is created with a default password set to "admin".
 
-### Configuration
+#### Configuration
 
 <details>
     <summary>Click to see configuration</summary>

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You can configure this package using a JSON structure as an argument to the `kur
 These arguments can either be provided manually:
 
 ```bash
-kurtosis run github.com/kurtosis-tech/rabbitmq-package '{"image":"rabbitmq:3-management"}'
+kurtosis run github.com/kurtosis-tech/rabbitmq-package '{"rabbitmq_image":"rabbitmq:3-management"}'
 ```
 
 or by loading via a file, for instance using the [args.json](args.json) file in this repo:

--- a/args.json
+++ b/args.json
@@ -1,0 +1,10 @@
+{
+    "rabbitmq_image": "rabbitmq:3-management",
+    "rabbitmq_num_nodes": 3,
+    "rabbitmq_management_port": 15672,
+    "rabbitmq_amqp_port": 5672,
+    "rabbitmq_admin_user": "admin",
+    "rabbitmq_admin_password": "admin",
+    "rabbitmq_vhost": "test",
+    "rabbitmq_env_vars": {}
+}


### PR DESCRIPTION
Move global args to the plan args to increase configurability and remove some dead code.